### PR TITLE
catch cases without 'File:' at the start of image

### DIFF
--- a/qic2.py
+++ b/qic2.py
@@ -56,6 +56,8 @@ parentRE = re.compile("^(.*)/[^/]*$")
 def doTagging(imageList, startTag, endTag, summary):
     global SITE, debug
     for image in imageList:
+		if 'File:' not in image:
+			image = "File:" + image
         page = pywikibot.Page(SITE, image)
 
         if page.exists():
@@ -85,7 +87,10 @@ def doTagging(imageList, startTag, endTag, summary):
                     )
                     pywikibot.showDiff(oldtext, text)
         else:
-            print("Oops " + image.encode("utf-8") + " doesn't exist...")
+			try:
+				print("Oops " + image.encode("utf-8") + " doesn't exist...")
+			except:
+				print("Error with" + str(image))
 
 
 #

--- a/qic2.py
+++ b/qic2.py
@@ -56,11 +56,13 @@ parentRE = re.compile("^(.*)/[^/]*$")
 def doTagging(imageList, startTag, endTag, summary):
     global SITE, debug
     for image in imageList:
-		if 'File:' not in image:
-			image = "File:" + image
-        page = pywikibot.Page(SITE, image)
-
-        if page.exists():
+		try:
+			page = pywikibot.FilePage(SITE, image)
+		except ValueError:
+			print("Oops " + image + " isn't a file...")
+		else:
+			if page.exists():
+				# ... and the rest also indented one extra level
             print("Tagging " + image)
 
             # follow redirects to the actual image page

--- a/qic2.py
+++ b/qic2.py
@@ -89,10 +89,7 @@ def doTagging(imageList, startTag, endTag, summary):
                     )
                     pywikibot.showDiff(oldtext, text)
         else:
-			try:
-				print("Oops " + image.encode("utf-8") + " doesn't exist...")
-			except:
-				print("Error with" + str(image))
+			print("Oops " + image + " doesn't exist...")
 
 
 #


### PR DESCRIPTION
There was an error on 28 May:

Tagging File:Immeuble_Lengema_Kisangani.jpg
Traceback (most recent call last):
  File "qic2.py", line 627, in <module>
    unassessed, unassessedCat, "", "Bot: Tag as unassessed Quality Image Candidate"
  File "qic2.py", line 88, in doTagging
    print("Oops " + image.encode("utf-8") + " doesn't exist...")
TypeError: Can't convert 'bytes' object to str implicitly
CRITICAL: Exiting due to uncaught exception <class 'TypeError'>

The next line was:
Praha Stare Mesto Templova mriz.jpg|{{../Nomination|Steel gate of a passage between Templová and Králodvorská, Old Town, Prague, Czechia --[[User:JiriMatejicek|JiriMatejicek]] 15:48, 19 May 2022 (UTC)}}

This change hopefully works around this issue of a missing 'File:'?